### PR TITLE
✨ feat: 프로필 이미지 변경 기능 및 최대인원에 따른 분기 기능 추가

### DIFF
--- a/src/main/java/com/junghun/common/domain/gathering/exception/FullGatheringException.java
+++ b/src/main/java/com/junghun/common/domain/gathering/exception/FullGatheringException.java
@@ -1,0 +1,8 @@
+package com.junghun.common.domain.gathering.exception;
+
+public class FullGatheringException extends RuntimeException {
+
+    public FullGatheringException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/junghun/common/domain/gathering/exception/NotProvideServiceLocationException.java
+++ b/src/main/java/com/junghun/common/domain/gathering/exception/NotProvideServiceLocationException.java
@@ -1,0 +1,8 @@
+package com.junghun.common.domain.gathering.exception;
+
+public class NotProvideServiceLocationException extends RuntimeException {
+
+    public NotProvideServiceLocationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/junghun/common/domain/gathering/repository/OneDayGatheringApplyStatusRepository.java
+++ b/src/main/java/com/junghun/common/domain/gathering/repository/OneDayGatheringApplyStatusRepository.java
@@ -2,6 +2,7 @@ package com.junghun.common.domain.gathering.repository;
 
 import com.junghun.common.domain.gathering.entity.OneDayGatheringApplyStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +11,9 @@ import java.util.List;
 public interface OneDayGatheringApplyStatusRepository extends JpaRepository<OneDayGatheringApplyStatus, Long> {
 
     List<OneDayGatheringApplyStatus> findByApplierIdAndOneDayGatheringId(Long applierId, Long oneDayGatheringId);
+
+    @Query("SELECT oa FROM OneDayGatheringApplyStatus oa " +
+            "WHERE oa.id = :oneDayGatheringId " +
+            "AND oa.status = true")
+    List<OneDayGatheringApplyStatus> findApprovedApplies(Long oneDayGatheringId);
 }

--- a/src/main/java/com/junghun/common/domain/gathering/service/OneDayGatheringApplyStatusService.java
+++ b/src/main/java/com/junghun/common/domain/gathering/service/OneDayGatheringApplyStatusService.java
@@ -3,7 +3,9 @@ package com.junghun.common.domain.gathering.service;
 import com.junghun.common.domain.gathering.entity.OneDayGathering;
 import com.junghun.common.domain.gathering.entity.OneDayGatheringApplyStatus;
 import com.junghun.common.domain.gathering.exception.AlreadyApplyGatheringException;
+import com.junghun.common.domain.gathering.exception.FullGatheringException;
 import com.junghun.common.domain.gathering.exception.NotFoundGatheringApplyStatusException;
+import com.junghun.common.domain.gathering.exception.NotProvideServiceLocationException;
 import com.junghun.common.domain.gathering.repository.OneDayGatheringApplyStatusRepository;
 import com.junghun.common.domain.user.entity.User;
 import com.junghun.common.domain.user.service.UserService;
@@ -23,13 +25,21 @@ public class OneDayGatheringApplyStatusService {
     public void applyGathering(Long applierId, Long oneDayGatheringId) {
 
         List<OneDayGatheringApplyStatus> oneDayGatheringApplyStatusList = repository.findByApplierIdAndOneDayGatheringId(applierId, oneDayGatheringId);
-
         if (!oneDayGatheringApplyStatusList.isEmpty()) {
             throw new AlreadyApplyGatheringException("이미 신청중이거나, 승인된 모임입니다.");
         }
 
+        List<OneDayGatheringApplyStatus> approvedApplies = repository.findApprovedApplies(oneDayGatheringId);
+
         User applier = userService.findById(applierId);
         OneDayGathering oneDayGathering = oneDayGatheringService.findById(oneDayGatheringId);
+
+        if (oneDayGathering.getCapacity() <= approvedApplies.size()) {
+            throw new FullGatheringException("참여자가 많아 더이상 참여신청을 할 수 없습니다.");
+        }
+        if (!applier.getLocation().get("city").equals(oneDayGathering.getLocation().get("city"))) {
+            throw new NotProvideServiceLocationException("현재 이용자의 위치에서는 하루모임에 참여할 수 없습니다.");
+        }
 
         OneDayGatheringApplyStatus oneDayGatheringApplyStatus = OneDayGatheringApplyStatus.builder()
                 .applier(applier)

--- a/src/main/java/com/junghun/common/domain/user/controller/UserController.java
+++ b/src/main/java/com/junghun/common/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,14 @@ public class UserController {
             @PathVariable Long userId,
             @RequestBody List<String> categoryList) {
         User updatedUser = service.updateCategory(userId, categoryList);
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    @PatchMapping("/{userId}/profileImage")
+    public ResponseEntity<User> updateProfileImage(
+            @PathVariable Long userId,
+            @RequestParam("file") MultipartFile image) {
+        User updatedUser = service.updateProfileImage(userId, image);
         return ResponseEntity.ok(updatedUser);
     }
 

--- a/src/main/java/com/junghun/common/domain/user/service/UserService.java
+++ b/src/main/java/com/junghun/common/domain/user/service/UserService.java
@@ -199,7 +199,9 @@ public class UserService {
     public User updateProfileImage(Long id, MultipartFile image) {
         User user = repository.findById(id)
                 .orElseThrow(() -> new NotFoundUserException(id + "을(를) 가진 User 가 존재하지 않습니다."));
+
         String profileImage = imageService.uploadImage(image,"profileImage");
+
         User updateUser = User.builder()
                 .id(user.getId())
                 .email(user.getEmail())

--- a/src/main/java/com/junghun/common/domain/user/service/UserService.java
+++ b/src/main/java/com/junghun/common/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.junghun.common.domain.user.service;
 
+import com.junghun.common.domain.image.service.ImageService;
 import com.junghun.common.domain.user.dto.InformationDto;
 import com.junghun.common.domain.user.dto.RegisterDto;
 import com.junghun.common.domain.user.entity.User;
@@ -12,6 +13,7 @@ import com.junghun.common.util.RegexUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -25,6 +27,7 @@ public class UserService {
 
     private final UserRepository repository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final ImageService imageService;
 
     // READ
     public User findById(Long id) {
@@ -187,6 +190,26 @@ public class UserService {
                 .location(ConvertUtils.getStringByMap(location))
                 .categoryList(ConvertUtils.getStringByList(user.getCategoryList()))
                 .profileImage(user.getProfileImage())
+                .information(user.getInformation())
+                .build();
+
+        return repository.save(updateUser);
+    }
+
+    public User updateProfileImage(Long id, MultipartFile image) {
+        User user = repository.findById(id)
+                .orElseThrow(() -> new NotFoundUserException(id + "을(를) 가진 User 가 존재하지 않습니다."));
+        String profileImage = imageService.uploadImage(image,"profileImage");
+        User updateUser = User.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .password(user.getPassword())
+                .gender(user.getGender())
+                .birthday(user.getBirthday())
+                .location(ConvertUtils.getStringByMap(user.getLocation()))
+                .categoryList(ConvertUtils.getStringByList(user.getCategoryList()))
+                .profileImage(profileImage)
                 .information(user.getInformation())
                 .build();
 


### PR DESCRIPTION
프로필 이미지 변경 기능 및 최대인원에 따른 분기 기능 추가
ProfileImage 는 
1. ImageService 에 이미지 업로드 요청 후 정상적으로 업로드 후 리턴된 주소를
2. User의 profileImage 필드를 새로 저장한 이미지 주소로 수정

최대인원 초과에 대한 확인은 status = true & oneDayGatheringId = 입력된 Id 에 해당하는 ApplyStatus 를 조회하여 size()를 통해 gathering의 capacity와 비교한다.